### PR TITLE
Add --tls-tcnative option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
     <slf4j.version>2.0.17</slf4j.version>
     <logback.version>1.5.18</logback.version>
     <netty.version>4.2.3.Final</netty.version>
+    <netty-tcnative.version>2.0.72.Final</netty-tcnative.version>
     <metrics.version>4.2.33</metrics.version>
     <micrometer.version>1.15.2</micrometer.version>
     <picocli.version>4.7.7</picocli.version>
@@ -155,6 +156,13 @@
     </dependency>
 
     <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>${netty-tcnative.version}</version>
+      <classifier>linux-x86_64</classifier>
+    </dependency>
+
+    <dependency>
       <groupId>org.jgroups</groupId>
       <artifactId>jgroups</artifactId>
       <version>${jgroups.version}</version>
@@ -202,6 +210,14 @@
       <artifactId>spotbugs-annotations</artifactId>
       <version>${spotbugs.version}</version>
       <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>${netty-tcnative.version}</version>
+      <classifier>osx-aarch_64</classifier>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/src/test/java/com/rabbitmq/stream/perf/Host.java
+++ b/src/test/java/com/rabbitmq/stream/perf/Host.java
@@ -94,7 +94,7 @@ final class Host {
   }
 
   static String rabbitmqctlCommand() {
-    String rabbitmqCtl = System.getProperty("rabbitmqctl.bin", DOCKER_PREFIX);
+    String rabbitmqCtl = System.getProperty("rabbitmqctl.bin", DOCKER_PREFIX + "rabbitmq");
     if (rabbitmqCtl.startsWith(DOCKER_PREFIX)) {
       String containerId = rabbitmqCtl.split(":")[1];
       return "docker exec " + containerId + " rabbitmqctl";

--- a/src/test/java/com/rabbitmq/stream/perf/StreamPerfTestTest.java
+++ b/src/test/java/com/rabbitmq/stream/perf/StreamPerfTestTest.java
@@ -70,6 +70,7 @@ import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @ExtendWith(TestUtils.StreamTestInfrastructureExtension.class)
 public class StreamPerfTestTest {
@@ -285,12 +286,14 @@ public class StreamPerfTestTest {
     waitRunEnds();
   }
 
-  @Test
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
   @DisabledIfTlsNotEnabled
-  void shouldConnectWithTls() throws Exception {
+  void shouldConnectWithTls(boolean tlsTcNative) throws Exception {
+    ArgumentsBuilder builder = builder().tlsTcNative(tlsTcNative);
     Future<?> run =
         run(
-            builder()
+            builder
                 .uris("rabbitmq-stream+tls://guest:guest@localhost:5551/%2f")
                 .serverNameIndication("localhost"));
     waitUntilStreamExists(s);
@@ -638,6 +641,11 @@ public class StreamPerfTestTest {
 
     ArgumentsBuilder uris(String url) {
       arguments.put("uris", url);
+      return this;
+    }
+
+    public ArgumentsBuilder tlsTcNative(boolean tlsTcNative) {
+      arguments.put("tls-tcnative", String.valueOf(tlsTcNative));
       return this;
     }
 


### PR DESCRIPTION
Uses Netty's tcnative module statically linked against BoringSSL.