### PR TITLE
Use noTrackingStrategy for SAC consumers without explicit --store-every

### DIFF
--- a/src/main/java/com/rabbitmq/stream/perf/StreamPerfTest.java
+++ b/src/main/java/com/rabbitmq/stream/perf/StreamPerfTest.java
@@ -1363,12 +1363,29 @@ public class StreamPerfTest implements Callable<Integer> {
                         if (this.singleActiveConsumer) {
                           consumerBuilder.singleActiveConsumer();
                           // single active consumer requires a name
-                          if (this.storeEvery == 0) {
-                            this.storeEvery = 10_000;
+                          String consumerName = this.consumerNameStrategy.apply(stream, i + 1);
+                          if (this.storeEvery > 0) {
+                            consumerBuilder =
+                                consumerBuilder
+                                    .name(consumerName)
+                                    .autoTrackingStrategy()
+                                    .messageCountBeforeStorage(this.storeEvery)
+                                    .builder();
+                          } else {
+                            // Use noTrackingStrategy to avoid a NPE in the stream-client library
+                            // when shutting down. Provide a consumer update listener that returns
+                            // the initial offset when going active so the broker gets a non-null
+                            // response (returning null can delay broker-side SAC processing).
+                            OffsetSpecification sacOffsetSpec = this.offset;
+                            consumerBuilder =
+                                consumerBuilder
+                                    .name(consumerName)
+                                    .noTrackingStrategy()
+                                    .consumerUpdateListener(
+                                        context ->
+                                            context.isActive() ? sacOffsetSpec : null);
                           }
-                        }
-
-                        if (this.storeEvery > 0) {
+                        } else if (this.storeEvery > 0) {
                           String consumerName = this.consumerNameStrategy.apply(stream, i + 1);
                           consumerBuilder =
                               consumerBuilder


### PR DESCRIPTION
When -sac is used without an explicit --store-every, the consumer previously got auto-tracking enabled silently. With this change, explicit --store-every is required, even for SAC consumers.

This PR started by investigating the following null pointer:

```
14:04:49.984 [rabbitmq-stream-consumer-connection-19] WARN  c.r.stream.impl.StreamConsumer - Error in consumer update listener
java.lang.NullPointerException: Cannot invoke "com.rabbitmq.stream.impl.Client$QueryOffsetResponse.isOk()" because "response" is null
        at com.rabbitmq.stream.impl.OffsetTrackingUtils.storedOffset(OffsetTrackingUtils.java:53)
        at com.rabbitmq.stream.impl.StreamConsumer.storedOffset(StreamConsumer.java:552)
        at com.rabbitmq.stream.impl.StreamConsumer.storedOffset(StreamConsumer.java:566)
        at com.rabbitmq.stream.impl.StreamConsumer.getStoredOffsetSafely(StreamConsumer.java:301)
        at com.rabbitmq.stream.impl.StreamConsumer.getStoredOffset(StreamConsumer.java:285)
        at com.rabbitmq.stream.impl.StreamConsumer.lambda$new$4(StreamConsumer.java:187)
        at com.rabbitmq.stream.impl.StreamConsumer.consumerUpdate(StreamConsumer.java:415)
        at com.rabbitmq.stream.impl.ConsumersCoordinator$ClientSubscriptionsManager.lambda$new$11(ConsumersCoordinator.java:861)
        at com.rabbitmq.stream.impl.ServerFrameHandler$ConsumerUpdateFrameHandler.doHandle(ServerFrameHandler.java:802)
        at com.rabbitmq.stream.impl.ServerFrameHandler$BaseFrameHandler.handle(ServerFrameHandler.java:289)
        at com.rabbitmq.stream.impl.Client$FrameHandlerTask.run(Client.java:3161)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:545)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:328)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
        at java.base/java.lang.Thread.run(Thread.java:1474)
```