### PR TITLE
Add manifest entry to suppress final field mutation warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -297,6 +297,13 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>${maven.jar.plugin.version}</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Enable-Final-Field-Mutation>ALL-UNNAMED</Enable-Final-Field-Mutation>
+            </manifestEntries>
+          </archive>
+        </configuration>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
When running on JDK 26+, the JVM warns that the stream-client library reflectively mutates the final field 'clientProperties' in Client$ClientParameters. JEP 500 introduced the Enable-Final-Field-Mutation JAR manifest attribute to opt in to this behaviour and silence the warning.