### PR TITLE
Fix Micrometer composite registry warning at startup

### DIFF
--- a/src/main/java/com/rabbitmq/stream/perf/DebugEndpointMonitoring.java
+++ b/src/main/java/com/rabbitmq/stream/perf/DebugEndpointMonitoring.java
@@ -14,6 +14,7 @@
 // info@rabbitmq.com.
 package com.rabbitmq.stream.perf;
 
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -30,13 +31,18 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import picocli.CommandLine.Option;
 
-class DebugEndpointMonitoring implements Monitoring {
+final class DebugEndpointMonitoring implements Monitoring {
 
   @Option(
       names = {"--monitoring"},
       description = "Enable HTTP endpoint for monitoring and debugging",
       defaultValue = "false")
   private boolean monitoring;
+
+  @Override
+  public void meterRegistry(CompositeMeterRegistry meterRegistry) {
+    // no op
+  }
 
   @Override
   public void configure(MonitoringContext context) {

--- a/src/main/java/com/rabbitmq/stream/perf/Monitoring.java
+++ b/src/main/java/com/rabbitmq/stream/perf/Monitoring.java
@@ -14,7 +14,11 @@
 // info@rabbitmq.com.
 package com.rabbitmq.stream.perf;
 
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+
 interface Monitoring {
+
+  void meterRegistry(CompositeMeterRegistry meterRegistry);
 
   void configure(MonitoringContext context);
 }

--- a/src/main/java/com/rabbitmq/stream/perf/PrometheusEndpointMonitoring.java
+++ b/src/main/java/com/rabbitmq/stream/perf/PrometheusEndpointMonitoring.java
@@ -14,13 +14,14 @@
 // info@rabbitmq.com.
 package com.rabbitmq.stream.perf;
 
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.prometheusmetrics.PrometheusConfig;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import picocli.CommandLine.Option;
 
-class PrometheusEndpointMonitoring implements Monitoring {
+final class PrometheusEndpointMonitoring implements Monitoring {
 
   @Option(
       names = {"--prometheus"},
@@ -31,10 +32,16 @@ class PrometheusEndpointMonitoring implements Monitoring {
   private volatile PrometheusMeterRegistry registry;
 
   @Override
-  public void configure(MonitoringContext context) {
+  public void meterRegistry(CompositeMeterRegistry meterRegistry) {
     if (enabled) {
       registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
-      context.meterRegistry().add(registry);
+      meterRegistry.add(registry);
+    }
+  }
+
+  @Override
+  public void configure(MonitoringContext context) {
+    if (enabled) {
       context.addHttpEndpoint(
           "metrics",
           "Prometheus metrics",

--- a/src/main/java/com/rabbitmq/stream/perf/StreamPerfTest.java
+++ b/src/main/java/com/rabbitmq/stream/perf/StreamPerfTest.java
@@ -901,23 +901,11 @@ public class StreamPerfTest implements Callable<Integer> {
 
     CompositeMeterRegistry meterRegistry = new CompositeMeterRegistry();
     meterRegistry.config().commonTags(this.metricsTags);
+    // registries that need to back the composite from the start (e.g. Prometheus)
+    // must be added before any meter is registered, otherwise Micrometer warns
+    // that meters registered earlier will not be reflected in them
+    this.monitorings.forEach(m -> m.meterRegistry(meterRegistry));
     String metricsPrefix = "rabbitmq.stream";
-    if (this.metricsCommandLineArguments) {
-      Tags tags;
-      if (this.arguments == null || this.arguments.length == 0) {
-        tags = Tags.of("command_line", "");
-      } else {
-        tags = Tags.of("command_line", Utils.commandLineMetrics(this.arguments));
-      }
-      Gauge.builder(metricsPrefix + ".args", () -> Integer.valueOf(1))
-          .tags(tags)
-          .register(meterRegistry);
-    }
-    this.metricsCollector =
-        new PerformanceMicrometerMetricsCollector(
-            meterRegistry, metricsPrefix, this.includeBatchSizeMetric);
-
-    Counter producerConfirm = meterRegistry.counter(metricsPrefix + ".producer_confirmed");
 
     Supplier<String> memoryReportSupplier;
     if (this.memoryReport) {
@@ -966,10 +954,28 @@ public class StreamPerfTest implements Callable<Integer> {
 
     try {
 
-      if (meterRegistry.getRegistries().isEmpty()) {
-        // we need at least one to do the calculations
+      if (meterRegistry.getRegistries().isEmpty() || this.summaryFile) {
+        // we need at least one registry to do the calculations, and specifically a
+        // Dropwizard one if a summary file is requested, regardless of other registries
         meterRegistry.add(MetricsUtils.dropwizardMeterRegistry());
       }
+
+      if (this.metricsCommandLineArguments) {
+        Tags tags;
+        if (this.arguments == null || this.arguments.length == 0) {
+          tags = Tags.of("command_line", "");
+        } else {
+          tags = Tags.of("command_line", Utils.commandLineMetrics(this.arguments));
+        }
+        Gauge.builder(metricsPrefix + ".args", () -> Integer.valueOf(1))
+            .tags(tags)
+            .register(meterRegistry);
+      }
+      this.metricsCollector =
+          new PerformanceMicrometerMetricsCollector(
+              meterRegistry, metricsPrefix, this.includeBatchSizeMetric);
+
+      Counter producerConfirm = meterRegistry.counter(metricsPrefix + ".producer_confirmed");
 
       this.performanceMetrics =
           new DefaultPerformanceMetrics(

--- a/src/main/java/com/rabbitmq/stream/perf/Utils.java
+++ b/src/main/java/com/rabbitmq/stream/perf/Utils.java
@@ -360,7 +360,7 @@ class Utils {
     }
   }
 
-  final static class PerformanceMicrometerMetricsCollector extends MicrometerMetricsCollector {
+  static final class PerformanceMicrometerMetricsCollector extends MicrometerMetricsCollector {
 
     private final IntConsumer publisherCallback;
 

--- a/src/main/java/com/rabbitmq/stream/perf/metrics/DefaultPerformanceMetrics.java
+++ b/src/main/java/com/rabbitmq/stream/perf/metrics/DefaultPerformanceMetrics.java
@@ -263,16 +263,13 @@ public final class DefaultPerformanceMetrics implements PerformanceMetrics {
         printStream.println(description);
       }
 
+      // the Dropwizard registry must have been set before
       DropwizardMeterRegistry dropwizardMeterRegistry =
           this.meterRegistry.getRegistries().stream()
               .filter(r -> r instanceof DropwizardMeterRegistry)
               .map(r -> (DropwizardMeterRegistry) r)
               .findAny()
-              .orElseGet(MetricsUtils::dropwizardMeterRegistry);
-
-      if (!this.meterRegistry.getRegistries().contains(dropwizardMeterRegistry)) {
-        this.meterRegistry.add(dropwizardMeterRegistry);
-      }
+              .orElseThrow();
 
       ConsoleReporter fileReporter =
           ConsoleReporter.forRegistry(dropwizardMeterRegistry.getDropwizardRegistry())


### PR DESCRIPTION
Meters were registered on the composite MeterRegistry (producer confirmed counter, command-line-arguments gauge, and everything DefaultPerformanceMetrics tracks) before any backing registry was attached to it. Micrometer warns in this situation because meters registered before a registry is added won't have their prior state reflected in it.

Give Monitoring implementations a chance to attach their own backing registry (e.g. Prometheus) to the composite as soon as it is created, before any meter exists. Fall back to a Dropwizard registry only when nothing else backs the composite yet, or when a summary file is requested, since that feature needs a Dropwizard registry specifically and Prometheus's registry can't be used interchangeably with it.

This also removes the now-unreachable fallback in
DefaultPerformanceMetrics that lazily created and attached a Dropwizard registry if none was found: that path would have hit the same warning and produced an under-counted summary file, since it ran after meters already existed.