### PR TITLE
Disable hostname verification when TLS is on

### DIFF
--- a/src/main/java/com/rabbitmq/stream/perf/StreamPerfTest.java
+++ b/src/main/java/com/rabbitmq/stream/perf/StreamPerfTest.java
@@ -1097,6 +1097,7 @@ public class StreamPerfTest implements Callable<Integer> {
                 SslContextBuilder.forClient()
                     .sslProvider(sslProvider)
                     .trustManager(Utils.TRUST_EVERYTHING_TRUST_MANAGER)
+                    .endpointIdentificationAlgorithm(null)
                     .build());
         environmentBuilder = tlsConfiguration.environmentBuilder();
         if (!this.sniServerNames.isEmpty()) {


### PR DESCRIPTION
We already trust any server, and not disabling hostname verification can confuse some SSL providers in this case. This is obviously not a setup to adopt in real system, but it is acceptable for a load testing tool, as it simplifies its usage.